### PR TITLE
Respect existing table name

### DIFF
--- a/src/FluentNHibernate/Visitors/ManyToManyTableNameVisitor.cs
+++ b/src/FluentNHibernate/Visitors/ManyToManyTableNameVisitor.cs
@@ -13,7 +13,7 @@ namespace FluentNHibernate.Visitors
             if (mapping.OtherSide == null)
             {
                 // uni-directional
-                mapping.Set(x => x.TableName, Layer.Defaults, mapping.ChildType.Name + "To" + mapping.ContainingEntityType.Name);
+                mapping.Set(x => x.TableName, Layer.Defaults, mapping.TableName ?? mapping.ChildType.Name + "To" + mapping.ContainingEntityType.Name);
             }
             else
             {


### PR DESCRIPTION
When a table name is already set, it shouldn't just be overriden.
